### PR TITLE
docs: improve usage documentation

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -2,18 +2,44 @@ package config
 
 import (
 	"flag"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 )
 
-var Port int
-var Directory string
-var LogLevel string
+var (
+	Port      int
+	Directory string
+	LogLevel  string
+)
 
 func initFlags() {
-	flag.IntVar(&Port, "p", 5030, "port")
-	flag.StringVar(&Directory, "d", ".", "directory")
-	flag.StringVar(&LogLevel, "log-level", "info", "log level")
+	flag.Usage = usage
+	flag.IntVar(&Port, "p", 5030, "Port to use (default 5030)")
+	flag.StringVar(&Directory, "d", ".", "Directory to serve (default '.')")
+	flag.StringVar(
+		&LogLevel,
+		"log-level",
+		"info",
+		"Set the logging level ('info', 'debug', 'warn', 'error') (default 'info')",
+	)
+}
+
+func usage() {
+	fmt.Println("usage: restatic [options]")
+	fmt.Println("")
+	fmt.Println("A simple HTTP server that serves a local directory over HTTP.")
+	fmt.Println("")
+	fmt.Println("options:")
+	fmt.Println("  -p --port         Port to use (default 5030)")
+	fmt.Println("  -d --directory    Directory to serve (default '.')")
+	fmt.Println(
+		"     --log-level    Set the logging level ('info', 'debug', 'warn', 'error') (default 'info')",
+	)
+	fmt.Println("")
+	fmt.Println(
+		"Read README.md for more help on how to use restatic",
+	)
 }
 
 func initLog() {


### PR DESCRIPTION
fixes #3 

```bash

	██████  ███████ ███████ ████████  █████  ████████ ██  ██████ 
	██   ██ ██      ██         ██    ██   ██    ██    ██ ██      
	██████  █████   ███████    ██    ███████    ██    ██ ██      
	██   ██ ██           ██    ██    ██   ██    ██    ██ ██      
	██   ██ ███████ ███████    ██    ██   ██    ██    ██  ██████ 
	
	by Relog - https://relog.in
	
usage: restatic [options]

A simple HTTP server that serves a local directory over HTTP.

options:
  -p --port         Port to use (default 5030)
  -d --directory    Directory to serve (default '.')
     --log-level    Set the logging level ('info', 'debug', 'warn', 'error') (default 'info')

Read README.md for more help on how to use restatic
```